### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "bootstrap": "^4.1.3",
     "jquery": "^3.3.1",
-    "npm": "^6.9.0",
     "popper.js": "^1.14.6"
   },
   "directories": {


### PR DESCRIPTION

Hello rsobrado!

It seems like you have npm as one of your (dev-) dependency in What-s-the-W.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
